### PR TITLE
Refactor targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 
 _targets/*
+*/out/*

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -5,7 +5,7 @@
 # load all files in download directory and combine into a dataframe
 combine_data <- function(in_dir) {
   
-  download_files <- file.path(in_dir,list.files(in_dir))
+  download_files <- list.files(in_dir, full.names = TRUE)
   data_out <- data.frame()
   # loop through files to download 
   for (download_file in download_files){
@@ -20,8 +20,8 @@ combine_data <- function(in_dir) {
 # ----------------------
 
 # Download site information for provided NWIS site numbers
-nwis_site_info <- function(fileout, site_no){
-  #site_no <- unique(site_data$site_no)
+nwis_site_info <- function(fileout, site_data){
+  site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)
   return(fileout)

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -2,21 +2,6 @@
 
 # -----------------------
 
-# download data from nwis for given site numbers and save as .csv files in output folder
-download_nwis_data <- function(site_nums, 
-                               out_path,
-                               params = '00010'){
-  
-  # create the file names that are needed for download_nwis_site_data
-
-  download_file <- file.path(out_path, paste0('nwis_', site_nums, '_data.csv'))
-  download_nwis_site_data(download_file, parameterCd = params)
-  
-  return(download_file) 
-}
- 
-# ----------------------
-
 # load all files in download directory and combine into a dataframe
 combine_data <- function(in_dir) {
   

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -3,9 +3,8 @@
 # -----------------------
 
 # load all files in download directory and combine into a dataframe
-combine_data <- function(in_dir) {
+combine_data <- function(download_files) {
   
-  download_files <- list.files(in_dir, full.names = TRUE)
   data_out <- data.frame()
   # loop through files to download 
   for (download_file in download_files){

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,14 +1,30 @@
+# Functions for downloading NWIS site data and info
 
-download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000", "01436690", "01466500")){
+# -----------------------
+
+# download data from nwis for given site numbers and save as .csv files in output folder
+download_nwis_data <- function(site_nums, 
+                               out_path,
+                               params = '00010'){
   
   # create the file names that are needed for download_nwis_site_data
-  # tempdir() creates a temporary directory that is wiped out when you start a new R session; 
-  # replace tempdir() with "1_fetch/out" or another desired folder if you want to retain the download
-  download_files <- file.path(tempdir(), paste0('nwis_', site_nums, '_data.csv'))
+
+  download_file <- file.path(out_path, paste0('nwis_', site_nums, '_data.csv'))
+  download_nwis_site_data(download_file, parameterCd = params)
+  
+  return(download_file) 
+}
+ 
+# ----------------------
+
+# load all files in download directory and combine into a dataframe
+combine_data <- function(in_dir) {
+  
+  download_files <- file.path(in_dir,list.files(in_dir))
   data_out <- data.frame()
   # loop through files to download 
   for (download_file in download_files){
-    download_nwis_site_data(download_file, parameterCd = '00010')
+    
     # read the downloaded data and append it to the existing data.frame
     these_data <- read_csv(download_file, col_types = 'ccTdcc')
     data_out <- bind_rows(data_out, these_data)
@@ -16,15 +32,22 @@ download_nwis_data <- function(site_nums = c("01427207", "01432160", "01435000",
   return(data_out)
 }
 
-nwis_site_info <- function(fileout, site_data){
-  site_no <- unique(site_data$site_no)
+# ----------------------
+
+# Download site information for provided NWIS site numbers
+nwis_site_info <- function(fileout, site_no){
+  #site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)
   return(fileout)
 }
 
+# -------------------------
 
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
+download_nwis_site_data <- function(filepath, 
+                                    parameterCd = '00010', 
+                                    startDate="2014-05-01", 
+                                    endDate="2015-05-01"){
   
   # filepaths look something like directory/nwis_01432160_data.csv,
   # remove the directory with basename() and extract the 01432160 with the regular expression match

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,19 +1,11 @@
-process_data <- function(nwis_data){
+process_data <- function(nwis_data, site_filename){
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd)
   
-  return(nwis_data_clean)
-}
-
-annotate_data <- function(site_data_clean, site_filename){
   site_info <- read_csv(site_filename)
-  annotated_data <- left_join(site_data_clean, site_info, by = "site_no") %>% 
-    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va)
+  site_data_styled <- left_join(nwis_data_clean, site_info, by = "site_no") %>% 
+    select(station_name = station_nm, site_no, dateTime, water_temperature, latitude = dec_lat_va, longitude = dec_long_va) %>%
+    mutate(station_name = as.factor(station_name))
   
-  return(annotated_data)
-}
-
-
-style_data <- function(site_data_annotated){
-  mutate(site_data_annotated, station_name = as.factor(station_name))
+  return(site_data_styled)
 }

--- a/3_visualize/src/plot_timeseries.R
+++ b/3_visualize/src/plot_timeseries.R
@@ -1,4 +1,4 @@
-plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 7, units = 'in'){
+plot_nwis_timeseries <- function(fileout, site_data_styled, width = 12, height = 8, units = 'in'){
   
   ggplot(data = site_data_styled, aes(x = dateTime, y = water_temperature, color = station_name)) +
     geom_line() + theme_bw()

--- a/_targets.R
+++ b/_targets.R
@@ -10,24 +10,29 @@ nwis_sites = c("01427207", "01432160", "01435000", "01436690", "01466500")
 # Download NWIS data and site info
 p1_targets_list <- list(
   tar_target(
-    site_data_01427207,
-    download_nwis_data(nwis_sites[1],'1_fetch/out/nwis_data/'),
+    site_data_01427207_csv,
+    download_nwis_site_data('1_fetch/out/nwis_data/nwis_data_01427207.csv'),
+    format = "file"
   ),
   tar_target(
-    site_data_01432160,
-    download_nwis_data(nwis_sites[2],'1_fetch/out/nwis_data/'),
+    site_data_01432160_csv,
+    download_nwis_site_data('1_fetch/out/nwis_data/nwis_data_01432160.csv'),
+    format = "file"
   ),
   tar_target(
-    site_data_01435000,
-    download_nwis_data(nwis_sites[3],'1_fetch/out/nwis_data/'),
+    site_data_01435000_csv,
+    download_nwis_site_data('1_fetch/out/nwis_data/nwis_data_01435000.csv'),
+    format = "file"
   ),
   tar_target(
-    site_data_01436690,
-    download_nwis_data(nwis_sites[4],'1_fetch/out/nwis_data/'),
+    site_data_01436690_csv,
+    download_nwis_site_data('1_fetch/out/nwis_data/nwis_data_01436690.csv'),
+    format = "file"
   ),
   tar_target(
-    site_data_01466500,
-    download_nwis_data(nwis_sites[5],'1_fetch/out/nwis_data/'),
+    site_data_01466500_csv,
+    download_nwis_site_data('1_fetch/out/nwis_data/nwis_data_01466500.csv'),
+    format = "file"
   ),
   tar_target(in_dir,'1_fetch/out/nwis_data',format ="file"),
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -33,10 +33,9 @@ p1_targets_list <- list(
     download_nwis_site_data('1_fetch/out/nwis_data/nwis_data_01466500.csv'),
     format = "file"
   ),
-  tar_target(in_dir,'1_fetch/out/nwis_data',format ="file"),
   tar_target(
     combined_nwis_data,
-    combine_data(in_dir),
+    combine_data(c(site_data_01427207_csv, site_data_01432160_csv, site_data_01435000_csv, site_data_01436690_csv, site_data_01466500_csv)),
   ),
   tar_target(
     site_info_csv,

--- a/_targets.R
+++ b/_targets.R
@@ -5,9 +5,6 @@ source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
-p_width <- 12
-p_height <- 7
-p_units <- "in"
 nwis_sites = c("01427207", "01432160", "01435000", "01436690", "01466500")
 
 # Download NWIS data and site info
@@ -57,7 +54,7 @@ p3_targets_list <- list(
   tar_target(
     figure_1_png,
     plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
-                         width = p_width, height = p_height, units = p_units),
+                         ),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -5,38 +5,59 @@ source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+p_width <- 12
+p_height <- 7
+p_units <- "in"
+nwis_sites = c("01427207", "01432160", "01435000", "01436690", "01466500")
 
+# Download NWIS data and site info
 p1_targets_list <- list(
   tar_target(
-    site_data,
-    download_nwis_data(),
+    site_data_01427207,
+    download_nwis_data(nwis_sites[1],'1_fetch/out/nwis_data/'),
+  ),
+  tar_target(
+    site_data_01432160,
+    download_nwis_data(nwis_sites[2],'1_fetch/out/nwis_data/'),
+  ),
+  tar_target(
+    site_data_01435000,
+    download_nwis_data(nwis_sites[3],'1_fetch/out/nwis_data/'),
+  ),
+  tar_target(
+    site_data_01436690,
+    download_nwis_data(nwis_sites[4],'1_fetch/out/nwis_data/'),
+  ),
+  tar_target(
+    site_data_01466500,
+    download_nwis_data(nwis_sites[5],'1_fetch/out/nwis_data/'),
+  ),
+  tar_target(in_dir,'1_fetch/out/nwis_data',format ="file"),
+  tar_target(
+    combined_nwis_data,
+    combine_data(in_dir),
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", nwis_sites),
     format = "file"
   )
 )
 
+# process and style data to prepare for plotting
 p2_targets_list <- list(
   tar_target(
-    site_data_clean, 
-    process_data(site_data)
-  ),
-  tar_target(
-    site_data_annotated,
-    annotate_data(site_data_clean, site_filename = site_info_csv)
-  ),
-  tar_target(
-    site_data_styled,
-    style_data(site_data_annotated)
+    site_data_styled, 
+    process_data(combined_nwis_data, site_info_csv)
   )
 )
 
+# plot data
 p3_targets_list <- list(
   tar_target(
     figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled),
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_styled,
+                         width = p_width, height = p_height, units = p_units),
     format = "file"
   )
 )

--- a/_targets.R
+++ b/_targets.R
@@ -5,7 +5,6 @@ source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
-nwis_sites = c("01427207", "01432160", "01435000", "01436690", "01466500")
 
 # Download NWIS data and site info
 p1_targets_list <- list(
@@ -41,7 +40,7 @@ p1_targets_list <- list(
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", nwis_sites),
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", combined_nwis_data),
     format = "file"
   )
 )


### PR DESCRIPTION
#5 
This PR refactors the code to better balance the targets in terms of time. I tried to setup the pipeline to rely on a downloaded NWIS directory as a target. I noticed the first time I ran the make file that the targets built in an unexpected order though and so needed to be run a second time before all the downloaded data were captured. I'm sure there is a way to set it up to avoid that issue, so any feedback is welcome :). Right now the pipeline visualization illustrates the issue that the downloaded files aren't connected in the graph to the directory target.
<img width="308" alt="Capture" src="https://user-images.githubusercontent.com/13355628/130846742-9805dd39-959d-4bc7-9791-2face491963b.PNG">
